### PR TITLE
Add highlight logic

### DIFF
--- a/Unity/Assets/Checkers/Board/Board.prefab
+++ b/Unity/Assets/Checkers/Board/Board.prefab
@@ -234,8 +234,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fc68e576303bdc54ea2c69f0a37c87c2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  WhitePiecePrefab: {fileID: 2961036102473875454, guid: c0aa80ac990f8aa4ea5963febc9a71aa,
-    type: 3}
+  RedPiecePrefab: {fileID: 0}
   BlackPiecePrefab: {fileID: 2961036102473875454, guid: b527abd5958f0024d915b29a28e6c968,
     type: 3}
   PiecesList: {fileID: 4426197651212536332}

--- a/Unity/Assets/Checkers/Board/Space.cs
+++ b/Unity/Assets/Checkers/Board/Space.cs
@@ -20,9 +20,15 @@ public class Space : MonoBehaviour
     
     // Stores a reference to the current occupant of itself
     [SerializeField] private Piece currentOccupant = null;
-    
+
+    // The highlight for possible moves.
+    [SerializeField] private GameObject TileHighlight;
+
     // Whether the current space is the "edge" of the board for king check
     private bool isEdge = false;
+
+    // Whether the current space represents a valid move for the player.
+    private bool highlighted = false;
     
     // Used for edge, color of side
     [SerializeField] private Piece.PieceColor color = Piece.PieceColor.NONE;
@@ -30,6 +36,10 @@ public class Space : MonoBehaviour
     // returns bool for if the space is currently occupied
     public bool isOccupied() {return currentOccupant != null;}
 
+    private void Start()
+    {
+        TileHighlight.SetActive(false);
+    }
 
     /// <summary>
     /// returns reference to current occupant
@@ -59,4 +69,24 @@ public class Space : MonoBehaviour
     /// sets color
     /// </summary>
     public void setColor(Piece.PieceColor color) {this.color = color;}
+
+    /// <summary>
+    /// Determines whether this piece is visible to the player.
+    /// </summary>
+    public bool isHighlighted() { return highlighted; }
+
+    /// <summary>
+    /// Shows or hides the highlight.
+    /// </summary>
+    public void setHighlighted(bool shouldBeVisible) {
+        TileHighlight.SetActive(shouldBeVisible);
+        highlighted = shouldBeVisible;
+    }
+
+    /// <summary>
+    /// Convenience method for checking whether the piece on the space matches a specific color.
+    /// </summary>
+    public bool currentOccupantIsColor(Piece.PieceColor pieceColor) {
+        return isOccupied() && currentOccupant.color == pieceColor;
+    }
 }

--- a/Unity/Assets/Checkers/Board/Space/Tile (1).prefab
+++ b/Unity/Assets/Checkers/Board/Space/Tile (1).prefab
@@ -62,6 +62,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 5585996207055051453}
+  - {fileID: 3932198844992350835}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -141,4 +142,87 @@ MonoBehaviour:
   y: 0
   piecePosition: {fileID: 5585996207055051453}
   currentOccupant: {fileID: 0}
+  TileHighlight: {fileID: 5293096110500568290}
+  TileHighlightPrefab: {fileID: 5293096110500568290}
   color: 2
+--- !u!1001 &1812939333999561424
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 6453188875692174596}
+    m_Modifications:
+    - target: {fileID: 3438815782427484323, guid: 9639b2a17d515f347814b12a038426d3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3438815782427484323, guid: 9639b2a17d515f347814b12a038426d3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.51
+      objectReference: {fileID: 0}
+    - target: {fileID: 3438815782427484323, guid: 9639b2a17d515f347814b12a038426d3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3438815782427484323, guid: 9639b2a17d515f347814b12a038426d3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3438815782427484323, guid: 9639b2a17d515f347814b12a038426d3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3438815782427484323, guid: 9639b2a17d515f347814b12a038426d3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3438815782427484323, guid: 9639b2a17d515f347814b12a038426d3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3438815782427484323, guid: 9639b2a17d515f347814b12a038426d3,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3438815782427484323, guid: 9639b2a17d515f347814b12a038426d3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3438815782427484323, guid: 9639b2a17d515f347814b12a038426d3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3438815782427484323, guid: 9639b2a17d515f347814b12a038426d3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5790503660555589170, guid: 9639b2a17d515f347814b12a038426d3,
+        type: 3}
+      propertyPath: m_Name
+      value: TileHighlight
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9639b2a17d515f347814b12a038426d3, type: 3}
+--- !u!1 &5293096110500568290 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5790503660555589170, guid: 9639b2a17d515f347814b12a038426d3,
+    type: 3}
+  m_PrefabInstance: {fileID: 1812939333999561424}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &3932198844992350835 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3438815782427484323, guid: 9639b2a17d515f347814b12a038426d3,
+    type: 3}
+  m_PrefabInstance: {fileID: 1812939333999561424}
+  m_PrefabAsset: {fileID: 0}

--- a/Unity/Assets/Checkers/Board/TileHighlight.prefab
+++ b/Unity/Assets/Checkers/Board/TileHighlight.prefab
@@ -1,0 +1,95 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5790503660555589170
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3438815782427484323}
+  - component: {fileID: 1105943155821828183}
+  - component: {fileID: 1043753521884854368}
+  - component: {fileID: 3348971539646575775}
+  m_Layer: 0
+  m_Name: TileHighlight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3438815782427484323
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5790503660555589170}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.09, y: 1.0000001, z: 0.09}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1105943155821828183
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5790503660555589170}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1043753521884854368
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5790503660555589170}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: c14837dfa515883428e5652d93e80c72, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &3348971539646575775
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5790503660555589170}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.9999998, z: 0.9999998}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Unity/Assets/Checkers/Board/TileHighlight.prefab.meta
+++ b/Unity/Assets/Checkers/Board/TileHighlight.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9639b2a17d515f347814b12a038426d3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Checkers/Piece/Piece.cs
+++ b/Unity/Assets/Checkers/Piece/Piece.cs
@@ -12,20 +12,13 @@ public class Piece : MonoBehaviour
     // Allow us to Promote to King
     [SerializeField] private GameObject king;
 
+    public bool kinged { get; private set; } = false;
 
     // Identify which player we belong to
     public enum PieceColor {BLACK, RED, NONE};
-    [SerializeField] public PieceColor color {get;private set;} = PieceColor.BLACK;
 
-
-    /// <summary>
-    /// Why is this here?
-    /// </summary>
-    public void setColor(PieceColor color)
-    {
-        this.color = color;
-    }
-
+    // The current color of the piece.
+    [SerializeField] public PieceColor color {get; set;} = PieceColor.BLACK;
 
     /// <summary>
     /// Promote a Man to a King
@@ -34,5 +27,6 @@ public class Piece : MonoBehaviour
     {
         // Display the "Crown"
         king.SetActive(true);
+        kinged = true;
     }
 }

--- a/Unity/Assets/Checkers/Player/PlayerManager.cs
+++ b/Unity/Assets/Checkers/Player/PlayerManager.cs
@@ -74,6 +74,7 @@ public class PlayerManager : MonoBehaviour
                     //if they are our piece, select them
                     if(space.getCurrentOccupant() != null && space.getCurrentOccupant().color == color)
                     {
+                        Board.getInstance().RequestFirstClick(space, color);
                         currentPieceSelected = space.getCurrentOccupant();
                         currentSpaceSelected = space;
                     }
@@ -82,6 +83,7 @@ public class PlayerManager : MonoBehaviour
                 {
                     if(space.getCurrentOccupant() == null)
                     {
+                        Board.getInstance().RequestSecondClick(space);
                         Board.getInstance().RequestMove(currentSpaceSelected.x,currentSpaceSelected.y,space.x,space.y);
                         currentSpaceSelected = null;
                         currentPieceSelected = null;

--- a/Unity/Assets/Checkers/Rule/BasicMoveRule.cs
+++ b/Unity/Assets/Checkers/Rule/BasicMoveRule.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Represents allowed diagonal movements of length 1 (i.e. no jumps).
+/// </summary>
+public class BasicMoveRule : MoveRule
+{
+    public BasicMoveRule(Board board) : base(board) {}
+
+    public override IEnumerable<Space> GetMoves(Space start)
+    {
+        Piece startPiece = start.getCurrentOccupant();
+        Piece.PieceColor? color = startPiece.color;
+        bool isKinged = startPiece != null && startPiece.kinged;
+        Tuple<int, int> startPos = board.GetLocBySpace(start);
+
+        List<Tuple<int, int>> DELTAS = new List<Tuple<int, int>>();
+
+        // Add back two positions if piece is red (or kinged).
+        if (isKinged || (color.HasValue && color.Value == Piece.PieceColor.RED))
+        {
+            DELTAS.Add(Tuple.Create( 1, 1));
+            DELTAS.Add(Tuple.Create(-1, 1));
+        }
+
+        // Add front two positions if piece is black (or kinged).
+        if (isKinged || (color.HasValue && color.Value == Piece.PieceColor.BLACK))
+        {
+            DELTAS.Add(Tuple.Create( 1,-1));
+            DELTAS.Add(Tuple.Create(-1,-1));
+        }
+
+        foreach (Tuple<int, int> delta in DELTAS) {
+            int x = startPos.Item1 + delta.Item1;
+            int y = startPos.Item2 + delta.Item2;
+
+            Space jumpOver = board.GetSpaceByLoc(x, y);
+
+            // Highlight adjacent spaces if they are empty.
+            if (jumpOver != null && !jumpOver.isOccupied())
+                yield return jumpOver;
+        }
+    }
+}

--- a/Unity/Assets/Checkers/Rule/BasicMoveRule.cs.meta
+++ b/Unity/Assets/Checkers/Rule/BasicMoveRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b527f9faf0b2bfc459e5f9459537ec06
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Checkers/Rule/JumpMoveRule.cs
+++ b/Unity/Assets/Checkers/Rule/JumpMoveRule.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Represents allowed diagonal movements of length 2 in which a piece jumps over another piece and captures it.
+/// </summary>
+public class JumpMoveRule : MoveRule
+{
+    public JumpMoveRule(Board board) : base(board) {}
+
+    public override IEnumerable<Space> GetMoves(Space start)
+    {
+        Piece startPiece = start.getCurrentOccupant();
+        Piece.PieceColor? color = startPiece.color;
+        bool isKinged = startPiece != null && startPiece.kinged;
+        Tuple<int, int> startPos = board.GetLocBySpace(start);
+
+        List<Tuple<int, int>> DELTAS = new List<Tuple<int, int>>();
+
+        // Add back two positions if piece is red (or kinged).
+        if (isKinged || (color.HasValue && color.Value == Piece.PieceColor.RED))
+        {
+            DELTAS.Add(Tuple.Create( 2, 2));
+            DELTAS.Add(Tuple.Create(-2, 2));
+        }
+
+        // Add front two positions if piece is black (or kinged).
+        if (isKinged || (color.HasValue && color.Value == Piece.PieceColor.BLACK))
+        {
+            DELTAS.Add(Tuple.Create( 2,-2));
+            DELTAS.Add(Tuple.Create(-2,-2));
+        }
+
+        foreach (Tuple<int, int> delta in DELTAS) {
+            int x0 = startPos.Item1 + (delta.Item1 / 2);
+            int y0 = startPos.Item2 + (delta.Item2 / 2);
+
+            Space jumpOver = board.GetSpaceByLoc(x0, y0);
+
+            int x1 = startPos.Item1 + delta.Item1;
+            int y1 = startPos.Item2 + delta.Item2;
+
+            Space jumpTarget = board.GetSpaceByLoc(x1, y1);
+
+            // Highlight spaces that are 1 length away on the diagonal if the player can jump.
+            bool isOpponentPiece = jumpOver != null && jumpOver.isOccupied() && jumpOver.currentOccupantIsColor(color.Value == Piece.PieceColor.BLACK ? Piece.PieceColor.BLACK : Piece.PieceColor.RED);
+            if (isOpponentPiece && jumpTarget != null && !jumpTarget.isOccupied())
+                yield return jumpTarget;
+        }
+    }
+}

--- a/Unity/Assets/Checkers/Rule/JumpMoveRule.cs.meta
+++ b/Unity/Assets/Checkers/Rule/JumpMoveRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e65ffbe933f475a4c89e1854ccd27bd1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Checkers/Rule/MoveRule.cs
+++ b/Unity/Assets/Checkers/Rule/MoveRule.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+/// <summary>
+/// Represents an abstract set of allowed movement rules based on a board and a starting space.
+/// </summary>
+public abstract class MoveRule
+{
+
+    /// <summary>
+    /// The board to determine whether moves are allowed.
+    /// </summary>
+    protected Board board { get; }
+
+    /// <summary>
+    /// Instantiantes a new rule checker with the given board.
+    /// </summary>
+    protected MoveRule(Board board)
+    {
+        this.board = board;
+    }
+
+    /// <summary>
+    /// Provides an enumerable set of spaces which are allowed from the given start space.
+    /// </summary>
+    public abstract IEnumerable<Space> GetMoves(Space start);
+}

--- a/Unity/Assets/Checkers/Rule/MoveRule.cs.meta
+++ b/Unity/Assets/Checkers/Rule/MoveRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5155e3764e606e141bc23f9e308f5a59
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Unity/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -32,5 +32,4 @@ MonoBehaviour:
   - DestroySpaceship
   - Fire
   - RespawnSpaceship
-  - SpawnPiece
   DisableAutoOpenWizard: 1


### PR DESCRIPTION
Added the logic to highlight the spaces that a player is allowed to move to.

A player should be able to either move one space diagonally forward if the target space is empty, or jump over an opponent piece if the adjacent space is empty.

The `MoveRule` class allows us to create rules for allowed moves and modify their behavior. This should fit into unit testing well.